### PR TITLE
Add failing acceptance test.

### DIFF
--- a/tests/acceptance/application-test.js
+++ b/tests/acceptance/application-test.js
@@ -1,0 +1,12 @@
+import { test } from 'qunit';
+import moduleForAcceptance from 'engine-testing/tests/helpers/module-for-acceptance';
+
+moduleForAcceptance('Acceptance | application');
+
+test('visiting /', function(assert) {
+  visit('/');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/');
+  });
+});


### PR DESCRIPTION
This test simply visits `/` which should mean that the various
route maps have been loaded, and we can link-to `eager` and `lazy`
engines.

It is currently failing because we are not properly including modules
imported by `lazy/addon/routes.js`:

```
Uncaught Error: Could not find module `lazy/lazy-import-target` imported from `lazy/routes`
    at missingModule (vendor.js:252)
    at findModule (vendor.js:263)
    at Module.findDeps (vendor.js:203)
    at findModule (vendor.js:266)
    at requireModule (vendor.js:33)
    at Class._extractDefaultExport (vendor.js:93623)
    at Class.resolveRouteMap (vendor.js:93438)
    at Class.resolve (vendor.js:15589)
    at resolve (vendor.js:12999)
    at Registry.resolve (vendor.js:12458)
```