### PR TITLE
Demonstrate issue in lazy engines including app/styles.

### DIFF
--- a/lib/lazy/lib/vanilla-addon-in-lazy/app/styles/vanilla-addon-in-lazy.css
+++ b/lib/lazy/lib/vanilla-addon-in-lazy/app/styles/vanilla-addon-in-lazy.css
@@ -1,0 +1,1 @@
+/* vanilla-addon-in-lazy/app/styles/foo.css */


### PR DESCRIPTION
When a lazy engine has an addon that includes app/styles as a dependency those styles are **always** hoisted to the top level app. This demonstrates that issue.