### PR TITLE
Add lazy engine with style preprocessors.

### DIFF
--- a/lib/lazy-with-style-preprocessors/addon/styles/addon.scss
+++ b/lib/lazy-with-style-preprocessors/addon/styles/addon.scss
@@ -1,0 +1,1 @@
+@import 'vanilla-addon-in-lazy-with-style-preprocessor';

--- a/lib/lazy-with-style-preprocessors/index.js
+++ b/lib/lazy-with-style-preprocessors/index.js
@@ -1,0 +1,11 @@
+/*jshint node:true*/
+var EngineAddon = require('ember-engines/lib/engine-addon');
+module.exports = EngineAddon.extend({
+  name: 'lazy-with-style-preprocessors',
+
+  lazyLoading: true,
+
+  isDevelopingAddon: function() {
+    return true;
+  },
+});

--- a/lib/lazy-with-style-preprocessors/lib/vanilla-addon-in-lazy-with-style-preprocessor/app/styles/vanilla-addon-in-lazy-with-style-preprocessor.scss
+++ b/lib/lazy-with-style-preprocessors/lib/vanilla-addon-in-lazy-with-style-preprocessor/app/styles/vanilla-addon-in-lazy-with-style-preprocessor.scss
@@ -1,0 +1,1 @@
+/* vanilla-addon-in-lazy-with-style-preprocessor */

--- a/lib/lazy-with-style-preprocessors/lib/vanilla-addon-in-lazy-with-style-preprocessor/index.js
+++ b/lib/lazy-with-style-preprocessors/lib/vanilla-addon-in-lazy-with-style-preprocessor/index.js
@@ -1,0 +1,8 @@
+/*jshint node:true*/
+module.exports = {
+  name: 'vanilla-addon-in-lazy-with-style-preprocessor',
+
+  isDevelopingAddon: function() {
+    return true;
+  },
+};

--- a/lib/lazy-with-style-preprocessors/lib/vanilla-addon-in-lazy-with-style-preprocessor/package.json
+++ b/lib/lazy-with-style-preprocessors/lib/vanilla-addon-in-lazy-with-style-preprocessor/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "vanilla-addon-in-lazy-with-style-preprocessor",
+  "keywords": [
+    "ember-addon",
+    "ember-engine"
+  ],
+  "dependencies": {},
+  "ember-addon": {
+    "paths": []
+  }
+}

--- a/lib/lazy-with-style-preprocessors/package.json
+++ b/lib/lazy-with-style-preprocessors/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "lazy-with-style-preprocessors",
+  "keywords": [
+    "ember-addon",
+    "ember-engine"
+  ],
+  "dependencies": {
+    "ember-ajax": "*",
+    "ember-cli-babel": "*",
+    "ember-cli-htmlbars": "*",
+    "ember-cli-sass": "*"
+  },
+  "ember-addon": {
+    "paths": [
+      "lib/vanilla-addon-in-lazy-with-style-preprocessor"
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "ember-cli-htmlbars-inline-precompile": "^0.3.3",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-qunit": "^3.0.4",
+    "ember-cli-sass": "^6.1.1",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
@@ -50,6 +51,7 @@
     "paths": [
       "lib/eager",
       "lib/lazy",
+      "lib/lazy-with-style-preprocessors",
       "lib/tree-invocation-order",
       "lib/vanilla-addon"
     ]


### PR DESCRIPTION
Demonstrates an issue in ember-engines build pipeline.

```
Build failed.
File: /Users/rjackson/src/open-source/engine-testing/tmp/sass_compiler-input_base_path-QgL1m6Fg.tmp/addon.scss (1)
The Broccoli Plugin: [SassCompiler] failed with:
Error: File to import not found or unreadable: vanilla-addon-in-lazy-with-style-preprocessor.
Parent style sheet: /Users/rjackson/src/open-source/engine-testing/tmp/sass_compiler-input_base_path-QgL1m6Fg.tmp/addon.scss
    at options.error (/Users/rjackson/src/open-source/engine-testing/node_modules/node-sass/lib/index.js:291:26)

The broccoli plugin was instantiated at:
    at SassCompiler.Plugin (/Users/rjackson/src/open-source/engine-testing/node_modules/broccoli-plugin/index.js:7:31)
    at SassCompiler.CachingWriter [as constructor] (/Users/rjackson/src/open-source/engine-testing/node_modules/broccoli-sass-source-maps/node_modules/broccoli-caching-writer/index.js:18:10)
    at new SassCompiler (/Users/rjackson/src/open-source/engine-testing/node_modules/broccoli-sass-source-maps/index.js:20:17)
    at /Users/rjackson/src/open-source/engine-testing/node_modules/ember-cli-sass/index.js:38:12
    at Array.map (native)
    at SASSPlugin.toTree (/Users/rjackson/src/open-source/engine-testing/node_modules/ember-cli-sass/index.js:35:34)
    at /Users/rjackson/src/open-source/engine-testing/node_modules/ember-cli-preprocess-registry/preprocessors.js:180:26
    at Array.forEach (native)
    at processPlugins (/Users/rjackson/src/open-source/engine-testing/node_modules/ember-cli-preprocess-registry/preprocessors.js:178:11)
    at module.exports.preprocessCss (/Users/rjackson/src/open-source/engine-testing/node_modules/ember-cli-preprocess-registry/preprocessors.js:148:10)
```