### PR TITLE
Move to ember-cli#beta channel

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "ember-cli-htmlbars-inline-precompile": "^0.3.3",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-qunit": "^3.0.4",
+    "ember-cli-shims": "^1.0.2",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^2.4.1",
-    "ember-cli": "github:ember-cli/ember-cli#canary",
+    "ember-cli": "2.12.0-beta.2",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-babel": "^5.1.7",
     "ember-cli-dependency-checker": "^1.3.0",


### PR DESCRIPTION
Since the `0.5.x` series is meant to be compatible with Ember-CLI 2.12, we should move to the beta channel and unbreak the build.